### PR TITLE
Kafka Serializer Config Update

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,8 +24,11 @@ spring:
             schema.registry.url: http://localhost:9081
             key.serializer: org.apache.kafka.common.serialization.StringSerializer
             value.serializer: io.confluent.kafka.serializers.KafkaAvroSerializer
+          consumer-properties:
+            schema.registry.url: http://localhost:9081
             key.deserializer: org.apache.kafka.common.serialization.StringDeserializer
-            value.deserializer: io.confluent.kafka.serializers.KafkaAvroDeserializer
+            value.deserializer: io.confluent.kafka.serializers.
+
           brokers: PLAINTEXT_HOST://localhost:30092
           min-partition-count: 1
           replication-factor: 1

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,6 +20,12 @@ spring:
         endpoint: http://localhost:9081
       kafka:
         binder:
+          producer-properties:
+            schema.registry.url: http://localhost:9081
+            key.serializer: org.apache.kafka.common.serialization.StringSerializer
+            value.serializer: io.confluent.kafka.serializers.KafkaAvroSerializer
+            key.deserializer: org.apache.kafka.common.serialization.StringDeserializer
+            value.deserializer: io.confluent.kafka.serializers.KafkaAvroDeserializer
           brokers: PLAINTEXT_HOST://localhost:30092
           min-partition-count: 1
           replication-factor: 1
@@ -41,10 +47,14 @@ spring:
           contentType: application/*+avro
           destination: redisandkafka.local.sample_event
           group: sample.local.sample_event
+          consumer:
+            useNativeDecoding: true
         sampleOutput:
           contentType: application/*+avro
           destination: redisandkafka.local.sample_event_output
           group: sample.local.sample_event
+          producer:
+            useNativeEncoding: true
 
 security.basic.enable: false
 management.security.enabled: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,7 +27,7 @@ spring:
           consumer-properties:
             schema.registry.url: http://localhost:9081
             key.deserializer: org.apache.kafka.common.serialization.StringDeserializer
-            value.deserializer: io.confluent.kafka.serializers.
+            value.deserializer: io.confluent.kafka.serializers.KafkaAvroDeserializer
 
           brokers: PLAINTEXT_HOST://localhost:30092
           min-partition-count: 1


### PR DESCRIPTION
The below mentioned config updates bypasses the default serializer auto configured by Spring Boot and uses the Serializer binded in the application.yml kafka config.

- Added config "useNativeEncoding : true" for producer
- Added config "useNativeEncoding: true" for consumer
- Introduced config producer-properties and added schema.registry.url, key.serializer, value.serializer to it.
- Introduced config consumer-properties and added schema.registry.url, key.deserializer, value.deserializer to it.
